### PR TITLE
Update snippets.html

### DIFF
--- a/snippets.html
+++ b/snippets.html
@@ -59,5 +59,5 @@ meta-desc: "Descriptions of, and links to, the DelphiDabbler Code Snippets Datab
 </h2>
 
 <p>
-  There are some unit tests available for a few of the snippets in the Code Snippets database. They can be downloaded from my GoogleDrive account as <a href="https://drive.google.com/file/d/1pH7LtyZY-ehwjJ4AjC801j-0bVMdLpsz/view?usp=sharing"><strong>CodeSnippetsUnitTests.zip</strong></a>.
+  There are some unit tests available for a few of the snippets in the Code Snippets Database. The tests for the latest release of the database can be downloaded from the project's <a href="https://github.com/delphidabbler/code-snippets/releases">Releases page</a>.
 </p>


### PR DESCRIPTION
Update link to Code Snippets Database tests to delphidabbler/code-snippets project releases tab from zip file on Google Drive.

Fixes #92 