### PR TITLE
Update documentation URLs on software pages

### DIFF
--- a/_software/aboutbox.html
+++ b/_software/aboutbox.html
@@ -187,7 +187,6 @@ status: "current"
       There is also an <a href="{{ page.faq-url }}">FAQ</a>.
     </p>
   </div>
-  </div>
 </section>
 
 <section class="panel panel-default">

--- a/_software/aboutbox.html
+++ b/_software/aboutbox.html
@@ -15,7 +15,8 @@ meta-title: "About Box Component for Delphi Pascal VCL | Open Source | 32 & 64 b
 meta-desc: "About Box dialogue box component for the Delphi Pascal VCL that can display the program's version information. Requires Delphi 2 & later."
 download-base-url: "https://sourceforge.net/projects/ddablib/files/aboutbox/"
 repo-url: "https://github.com/ddablib/aboutbox"
-docs-url: https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/AboutBox.md"
+docs-url: "https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/AboutBox.md"
+faq-url: "https://github.com/delphidabbler/ddab-lib-docs/blob/master/FAQs/AboutBoxComponent.md"
 want-header-buttons: true
 status: "current"
 ---
@@ -183,7 +184,7 @@ status: "current"
 			</p>
     </div>
     <p>
-      There is also an <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/FAQs/AboutBoxComponent.md">FAQ</a>.
+      There is also an <a href="{{ page.faq-url }}">FAQ</a>.
     </p>
   </div>
   </div>
@@ -203,7 +204,7 @@ status: "current"
       If you have created a bug fix or have implemented a new feature please open a pull request for it.
     </p>
     <p>
-      Should you have any queries about using the component please read the <a href="{{ page.docs-url }}">documentation</a> and/or <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/FAQs/AboutBoxComponent.md">FAQ</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
+      Should you have any queries about using the component please read the <a href="{{ page.docs-url }}">documentation</a> and/or <a href="{{ page.faq-url }}">FAQ</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
     </p>
   </div>
 </section>

--- a/_software/aboutbox.html
+++ b/_software/aboutbox.html
@@ -15,6 +15,7 @@ meta-title: "About Box Component for Delphi Pascal VCL | Open Source | 32 & 64 b
 meta-desc: "About Box dialogue box component for the Delphi Pascal VCL that can display the program's version information. Requires Delphi 2 & later."
 download-base-url: "https://sourceforge.net/projects/ddablib/files/aboutbox/"
 repo-url: "https://github.com/ddablib/aboutbox"
+docs-url: https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/AboutBox.md"
 want-header-buttons: true
 status: "current"
 ---
@@ -162,7 +163,7 @@ status: "current"
   </div>
   <div class="panel-body">
     <p>
-      The <em>{{page.title}}</em> is comprehensively documented online <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/AboutBox.md" aria-title="View the online documentation">here</a>
+      The <em>{{page.title}}</em> is comprehensively documented online <a href="{{ page.docs-url }}" aria-title="View the online documentation">here</a>
     </p>
     <p>
       The project's change log can be viewed <a href="https://raw.githubusercontent.com/ddablib/aboutbox/main/Docs/ChangeLog.txt" aria-title="View the change log in plain text">here</a>.
@@ -202,7 +203,7 @@ status: "current"
       If you have created a bug fix or have implemented a new feature please open a pull request for it.
     </p>
     <p>
-      Should you have any queries about using the component please read the <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/AboutBox.md">documentation</a> and/or <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/FAQs/AboutBoxComponent.md">FAQ</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
+      Should you have any queries about using the component please read the <a href="{{ page.docs-url }}">documentation</a> and/or <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/FAQs/AboutBoxComponent.md">FAQ</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
     </p>
   </div>
 </section>

--- a/_software/cbview.html
+++ b/_software/cbview.html
@@ -15,6 +15,7 @@ meta-title: "Clipboard Viewer Component for Delphi Pascal VCL | 32 & 64 bit | Op
 meta-desc: "Non visual component for the Delphi Pascal VCL that triggers an event when the Windows clipboard content changes. Requires Delphi 7 & later."
 download-base-url: "https://sourceforge.net/projects/ddablib/files/cbview/"
 repo-url: "https://github.com/ddablib/cbview"
+docs-url: "https://lib-docs.delphidabbler.com/CBView/"
 want-header-buttons: true
 status: "current"
 ---
@@ -115,7 +116,7 @@ status: "current"
   </div>
   <div class="panel-body">
     <p>
-      The <em>Clipboad Viewer Component</em> is comprehensively documented online <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/CBView.md" aria-title="View the online documentation">here</a>
+      The <em>Clipboad Viewer Component</em> is comprehensively documented online <a href="{{ page.docs-url }}" aria-title="View the online documentation">here</a>
     </p>
     <p>
       The project's change log can be viewed <a href="https://raw.githubusercontent.com/ddablib/cbview/main/Docs/ChangeLog.txt" aria-title="View the change log in plain text">here</a>.
@@ -140,7 +141,7 @@ status: "current"
       If you have created a bug fix or have implemented a new feature please open a pull request for it.
     </p>
     <p>
-      Should you have any queries about using the component please read the <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/CBView.md">documentation</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
+      Should you have any queries about using the component please read the <a href="{{ page.docs-url }}">documentation</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
     </p>
   </div>
 </section>

--- a/_software/consoleapp.html
+++ b/_software/consoleapp.html
@@ -16,6 +16,7 @@ meta-desc: "Delphi Pascal classes that simplify execution of child console proce
 download-base-url: "https://sourceforge.net/projects/ddablib/files/consoleapp/"
 repo-url: "https://github.com/ddablib/consoleapp"
 docs-url: "https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/ConsoleApp.md"
+faq-url: "https://github.com/delphidabbler/ddab-lib-docs/blob/master/FAQs/ConsoleAppClasses.md"
 want-header-buttons: true
 status: "current"
 ---
@@ -151,7 +152,7 @@ status: "current"
       A read-me file (<code>ReadMe.htm</code>) is included in the project download.
     </p>
     <p>
-      The is also an <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/FAQs/ConsoleAppClasses.md">FAQ</a>.
+      The is also an <a href="{{ page.faq-url }}">FAQ</a>.
     </p>
   </div>
 </section>
@@ -170,7 +171,7 @@ status: "current"
       If you have created a bug fix or have implemented a new feature please open a pull request for it.
     </p>
     <p>
-      Should you have any queries about using the classes please read the <a href="{{ page.docs-url }}">documentation</a> and/or <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/FAQs/ConsoleAppClasses.md">FAQ</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
+      Should you have any queries about using the classes please read the <a href="{{ page.docs-url }}">documentation</a> and/or <a href="{{ page.faq-url }}">FAQ</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
     </p>
   </div>
 </section>

--- a/_software/consoleapp.html
+++ b/_software/consoleapp.html
@@ -15,6 +15,7 @@ meta-title: "Console Application Runner Classes for Delphi Pascal | Open Source 
 meta-desc: "Delphi Pascal classes that simplify execution of child console processes and redirection of their standard input/output. Require Delphi 7 & later"
 download-base-url: "https://sourceforge.net/projects/ddablib/files/consoleapp/"
 repo-url: "https://github.com/ddablib/consoleapp"
+docs-url: "https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/ConsoleApp.md"
 want-header-buttons: true
 status: "current"
 ---
@@ -141,7 +142,7 @@ status: "current"
   </div>
   <div class="panel-body">
     <p>
-      The <em>{{page.title}}</em> are comprehensively documented online <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/ConsoleApp.md" aria-title="View the online documentation">here</a>
+      The <em>{{page.title}}</em> are comprehensively documented online <a href="{{ page.docs-url }}" aria-title="View the online documentation">here</a>
     </p>
     <p>
       The project's change log can be viewed <a href="https://raw.githubusercontent.com/ddablib/consoleapp/main/Docs/ChangeLog.txt" aria-title="View the change log in plain text">here</a>.
@@ -169,7 +170,7 @@ status: "current"
       If you have created a bug fix or have implemented a new feature please open a pull request for it.
     </p>
     <p>
-      Should you have any queries about using the classes please read the <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/ConsoleApp.md">documentation</a> and/or <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/FAQs/ConsoleAppClasses.md">FAQ</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
+      Should you have any queries about using the classes please read the <a href="{{ page.docs-url }}">documentation</a> and/or <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/FAQs/ConsoleAppClasses.md">FAQ</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
     </p>
   </div>
 </section>

--- a/_software/dropfiles.html
+++ b/_software/dropfiles.html
@@ -15,6 +15,7 @@ meta-title: "File Drag Drop Components for Delphi Pascal VCL | Open Source | 32 
 meta-desc: "Delphi Pascal VCL components that get and filter the names of files and folders dragged and dropped from Windows Explorer. Require Delphi 7 & later."
 download-base-url: "https://sourceforge.net/projects/ddablib/files/dropfiles/"
 repo-url: "https://github.com/ddablib/dropfiles"
+docs-url: "https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/DropFilesComponents.md"
 want-header-buttons: true
 status: "current"
 ---
@@ -247,7 +248,7 @@ status: "current"
   </div>
   <div class="panel-body">
     <p>
-      The <em>{{page.title}}</em> are comprehensively documented online <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/DropFilesComponents.md" aria-title="View the online documentation">here</a>
+      The <em>{{page.title}}</em> are comprehensively documented online <a href="{{ page.docs-url }}" aria-title="View the online documentation">here</a>
     </p>
     <p>
       The project's change log can be viewed <a href="https://raw.githubusercontent.com/ddablib/dropfiles/main/Docs/ChangeLog.txt" aria-title="View the change log in plain text">here</a>.
@@ -286,7 +287,7 @@ status: "current"
       If you have created a bug fix or have implemented a new feature please open a pull request for it.
     </p>
     <p>
-      Should you have any queries about using the components please read the <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/DropFilesComponents.md">documentation</a> and/or <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/FAQs/DropFilesComponents.md">FAQ</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
+      Should you have any queries about using the components please read the <a href="{{ page.docs-url }}">documentation</a> and/or <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/FAQs/DropFilesComponents.md">FAQ</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
     </p>
   </div>
 </section>

--- a/_software/dropfiles.html
+++ b/_software/dropfiles.html
@@ -16,6 +16,7 @@ meta-desc: "Delphi Pascal VCL components that get and filter the names of files 
 download-base-url: "https://sourceforge.net/projects/ddablib/files/dropfiles/"
 repo-url: "https://github.com/ddablib/dropfiles"
 docs-url: "https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/DropFilesComponents.md"
+faq-url: "https://github.com/delphidabbler/ddab-lib-docs/blob/master/FAQs/DropFilesComponents.md"
 want-header-buttons: true
 status: "current"
 ---
@@ -268,7 +269,7 @@ status: "current"
 			</p>
     </div>
     <p>
-      There is also an <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/FAQs/DropFilesComponents.md">FAQ</a>.
+      There is also an <a href="{{ page.faq-url }}">FAQ</a>.
     </p>
   </div>
 </section>
@@ -287,7 +288,7 @@ status: "current"
       If you have created a bug fix or have implemented a new feature please open a pull request for it.
     </p>
     <p>
-      Should you have any queries about using the components please read the <a href="{{ page.docs-url }}">documentation</a> and/or <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/FAQs/DropFilesComponents.md">FAQ</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
+      Should you have any queries about using the components please read the <a href="{{ page.docs-url }}">documentation</a> and/or <a href="{{ page.faq-urlm }}">FAQ</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
     </p>
   </div>
 </section>

--- a/_software/envvars.html
+++ b/_software/envvars.html
@@ -15,6 +15,7 @@ meta-title: "Environment Variables Unit for Delphi Pascal VCL & FMX | Open Sourc
 meta-desc: "Delphi Pascal unit for reading & writing Windows environment variables & for creating environment blocks for child processes. Requires Delphi 7 & later."
 download-base-url: "https://sourceforge.net/projects/ddablib/files/envvars/"
 repo-url: "https://github.com/ddablib/envvars"
+docs-url: "https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/EnvVars.md"
 want-header-buttons: true
 status: "current"
 ---
@@ -170,7 +171,7 @@ status: "current"
   </div>
   <div class="panel-body">
     <p>
-      The <em>{{page.title}}</em> is comprehensively documented online <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/EnvVars.md" aria-title="View the online documentation">here</a>
+      The <em>{{page.title}}</em> is comprehensively documented online <a href="{{ page.docs-url }}" aria-title="View the online documentation">here</a>
     </p>
     <p>
       The project's change log can be viewed <a href="https://raw.githubusercontent.com/ddablib/envvars/main/Docs/ChangeLog.txt" aria-title="View the change log in plain text">here</a>.
@@ -195,7 +196,7 @@ status: "current"
       If you have created a bug fix or have implemented a new feature please open a pull request for it.
     </p>
     <p>
-      Should you have any queries about using the unit please read the <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/EnvVars.md">documentation</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
+      Should you have any queries about using the unit please read the <a href="{{ page.docs-url }}">documentation</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
     </p>
   </div>
 </section>

--- a/_software/fractions.html
+++ b/_software/fractions.html
@@ -15,6 +15,7 @@ meta-title: "Fractions Manipulation Unit for Delphi Pascal | Open Source | 32 & 
 meta-desc: "Advanced Delphi Pascal record that stores and manipulates fractions. Has overloaded operators & numerous operations. Requires Delphi 2009 & later."
 download-base-url: "https://sourceforge.net/projects/ddablib/files/fractions/"
 repo-url: "https://github.com/ddablib/fractions"
+docs-url: "https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/Fractions.md"
 want-header-buttons: true
 status: "current"
 ---
@@ -117,7 +118,7 @@ status: "current"
   </div>
   <div class="panel-body">
     <p>
-      The <em>{{page.title}}</em> is comprehensively documented online <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/Fractions.md" aria-title="View the online documentation">here</a>
+      The <em>{{page.title}}</em> is comprehensively documented online <a href="{{ page.docs-url }}" aria-title="View the online documentation">here</a>
     </p>
     <p>
       The project's change log can be viewed <a href="https://raw.githubusercontent.com/ddablib/fractions/main/Docs/ChangeLog.txt" aria-title="View the change log in plain text">here</a>.
@@ -142,7 +143,7 @@ status: "current"
       If you have created a bug fix or have implemented a new feature please open a pull request for it.
     </p>
     <p>
-      Should you have any queries about using the unit please read the <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/Fractions.md">documentation</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
+      Should you have any queries about using the unit please read the <a href="{{ page.docs-url }}">documentation</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
     </p>
   </div>
 </section>

--- a/_software/hotlabel.html
+++ b/_software/hotlabel.html
@@ -15,6 +15,7 @@ meta-title: "Clickable Link Label Component for Delphi Pascal VCL that opens URL
 meta-desc: "Delphi Pascal VCL component that opens a specified URL when clicked. Link, hover & visited colours can be customised. Descends from TLabel. Requires Delphi 7 & later."
 download-base-url: "https://sourceforge.net/projects/ddablib/files/hotlabel/"
 repo-url: "https://github.com/ddablib/hotlabel"
+docs-url: "https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/HotLabelComponent.md"
 want-header-buttons: true
 status: "current"
 ---
@@ -184,7 +185,7 @@ status: "current"
   </div>
   <div class="panel-body">
     <p>
-      The <em>{{page.title}}</em> is comprehensively documented online <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/HotLabelComponent.md" aria-title="View the online documentation">here</a>
+      The <em>{{page.title}}</em> is comprehensively documented online <a href="{{ page.docs-url }}" aria-title="View the online documentation">here</a>
     </p>
     <p>
       The project's change log can be viewed <a href="https://raw.githubusercontent.com/ddablib/hotlabel/main/Docs/ChangeLog.txt" aria-title="View the change log in plain text">here</a>.
@@ -209,7 +210,7 @@ status: "current"
       If you have created a bug fix or have implemented a new feature please open a pull request for it.
     </p>
     <p>
-      Should you have any queries about using the component please read the <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/HotLabelComponent.md">documentation</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
+      Should you have any queries about using the component please read the <a href="{{ page.docs-url }}">documentation</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
     </p>
   </div>
 </section>

--- a/_software/ioutils.html
+++ b/_software/ioutils.html
@@ -15,6 +15,7 @@ meta-title: "File & Pipe IO Utility Classes for Delphi Pascal VCL | Open Source 
 meta-desc: "Delphi Pascal classes that encapsulate Windows pipes and file handles. Has filters for reading Unicode & ANSI text from pipes. Required Delphi 2005 & later."
 download-base-url: "https://sourceforge.net/projects/ddablib/files/ioutils/"
 repo-url: "https://github.com/ddablib/ioutils"
+docs-url: "https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/IOUtils.md"
 want-header-buttons: true
 status: "current"
 ---
@@ -134,7 +135,7 @@ status: "current"
   </div>
   <div class="panel-body">
     <p>
-      The <em>{{page.title}}</em> are comprehensively documented online <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/IOUtils.md" aria-title="View the online documentation">here</a>
+      The <em>{{page.title}}</em> are comprehensively documented online <a href="{{ page.docs-url }}" aria-title="View the online documentation">here</a>
     </p>
     <p>
       The project's change log can be viewed <a href="https://raw.githubusercontent.com/ddablib/ioutils/main/Docs/ChangeLog.txt" aria-title="View the change log in plain text">here</a>.
@@ -159,7 +160,7 @@ status: "current"
       If you have created a bug fix or have implemented a new feature please open a pull request for it.
     </p>
     <p>
-      Should you have any queries about using the classes please read the <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/IOUtils.md">documentation</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
+      Should you have any queries about using the classes please read the <a href="{{ page.docs-url }}">documentation</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
     </p>
   </div>
 </section>

--- a/_software/md5.html
+++ b/_software/md5.html
@@ -15,6 +15,7 @@ meta-title: "Comprehensive MD5 Calculation Unit for Delphi Pascal | Open Source 
 meta-desc: "Delphi Pascal class that calculates MD5 hashes for various data types & files. Passes all tests specified in RFC 1321. Requires Delphi 2009 & later."
 download-base-url: "https://sourceforge.net/projects/ddablib/files/md5/"
 repo-url: "https://github.com/ddablib/md5"
+docs-url: "https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/MD5.md"
 want-header-buttons: true
 status: "current"
 ---
@@ -187,7 +188,7 @@ status: "current"
   </div>
   <div class="panel-body">
     <p>
-      The <em>{{page.title}}</em> is comprehensively documented online <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/MD5.md" aria-title="View the online documentation">here</a>
+      The <em>{{page.title}}</em> is comprehensively documented online <a href="{{ page.docs-url }}" aria-title="View the online documentation">here</a>
     </p>
     <p>
       The project's change log can be viewed <a href="https://raw.githubusercontent.com/ddablib/md5/main/Docs/ChangeLog.txt" aria-title="View the change log in plain text">here</a>.
@@ -212,7 +213,7 @@ status: "current"
       If you have created a bug fix or have implemented a new feature please open a pull request for it.
     </p>
     <p>
-      Should you have any queries about using the unit please read the <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/MD5.md">documentation</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
+      Should you have any queries about using the unit please read the <a href="{{ page.docs-url }}">documentation</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
     </p>
   </div>
 </section>

--- a/_software/msgdlg.html
+++ b/_software/msgdlg.html
@@ -15,6 +15,7 @@ meta-title: "Message Dialogue Components for Delphi Pascal VCL | Open Source | 3
 meta-desc: "Delphi Pascal VCL components that provide wrappers for both the Windows API and Delphi VCL message boxes. Requires Delphi 7 & later."
 download-base-url: "https://sourceforge.net/projects/ddablib/files/msgdlg/"
 repo-url: "https://github.com/ddablib/msgdlg"
+docs-url: "https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/MessageDialogComponents.md"
 want-header-buttons: true
 status: "current"
 ---
@@ -123,7 +124,7 @@ status: "current"
   </div>
   <div class="panel-body">
     <p>
-      The <em>{{page.title}}</em> are comprehensively documented online <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/MessageDialogComponents.md" aria-title="View the online documentation">here</a>
+      The <em>{{page.title}}</em> are comprehensively documented online <a href="{{ page.docs-url }}" aria-title="View the online documentation">here</a>
     </p>
     <p>
       The project's change log can be viewed <a href="https://raw.githubusercontent.com/ddablib/msgdlg/main/Docs/ChangeLog.txt" aria-title="View the change log in plain text">here</a>.
@@ -151,7 +152,7 @@ status: "current"
       If you have created a bug fix or have implemented a new feature please open a pull request for it.
     </p>
     <p>
-      Should you have any queries about using the components please read the <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/MessageDialogComponents.md">documentation</a> and/or <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/FAQs/MessageDialogComponents.md">FAQ</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
+      Should you have any queries about using the components please read the <a href="{{ page.docs-url }}">documentation</a> and/or <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/FAQs/MessageDialogComponents.md">FAQ</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
     </p>
   </div>
 </section>

--- a/_software/msgdlg.html
+++ b/_software/msgdlg.html
@@ -16,6 +16,7 @@ meta-desc: "Delphi Pascal VCL components that provide wrappers for both the Wind
 download-base-url: "https://sourceforge.net/projects/ddablib/files/msgdlg/"
 repo-url: "https://github.com/ddablib/msgdlg"
 docs-url: "https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/MessageDialogComponents.md"
+faq-url: "https://github.com/delphidabbler/ddab-lib-docs/blob/master/FAQs/MessageDialogComponents.md"
 want-header-buttons: true
 status: "current"
 ---
@@ -133,7 +134,7 @@ status: "current"
       A read-me file (<code>ReadMe.htm</code>) is included in the project download.
     </p>
     <p>
-      There is also an <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/FAQs/MessageDialogComponents.md">FAQ</a>.
+      There is also an <a href="{{ page.faq-url }}">FAQ</a>.
     </p>
   </div>
 </section>
@@ -152,7 +153,7 @@ status: "current"
       If you have created a bug fix or have implemented a new feature please open a pull request for it.
     </p>
     <p>
-      Should you have any queries about using the components please read the <a href="{{ page.docs-url }}">documentation</a> and/or <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/FAQs/MessageDialogComponents.md">FAQ</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
+      Should you have any queries about using the components please read the <a href="{{ page.docs-url }}">documentation</a> and/or <a href="{{ page.faq-url }}">FAQ</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
     </p>
   </div>
 </section>

--- a/_software/resfile.html
+++ b/_software/resfile.html
@@ -15,6 +15,7 @@ meta-title: "Windows Resource File Manipulation Classes for Delphi Pascal | Open
 meta-desc: "Delphi Pascal classes for reading, creating & editing Windows 32 bit resource files + various helper functions. Requires Delphi 7 & later."
 download-base-url: "https://sourceforge.net/projects/ddablib/files/resfile/"
 repo-url: "https://github.com/ddablib/resfile"
+docs-url: "https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/ResFileUnit.md"
 want-header-buttons: true
 status: "current"
 ---
@@ -143,7 +144,7 @@ status: "current"
   </div>
   <div class="panel-body">
     <p>
-      The <em>{{page.title}}</em> is comprehensively documented online <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/ResFileUnit.md" aria-title="View the online documentation">here</a>
+      The <em>{{page.title}}</em> is comprehensively documented online <a href="{{ page.docs-url }}" aria-title="View the online documentation">here</a>
     </p>
     <p>
       The project's change log can be viewed <a href="https://raw.githubusercontent.com/ddablib/resfile/main/Docs/ChangeLog.txt" aria-title="View the change log in plain text">here</a>.
@@ -168,7 +169,7 @@ status: "current"
       If you have created a bug fix or have implemented a new feature please open a pull request for it.
     </p>
     <p>
-      Should you have any queries about using the unit please read the <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/ResFileUnit.md">documentation</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
+      Should you have any queries about using the unit please read the <a href="{{ page.docs-url }}">documentation</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
     </p>
   </div>
 </section>

--- a/_software/shellfolders.html
+++ b/_software/shellfolders.html
@@ -15,6 +15,7 @@ meta-title: "Windows Shell Folders Components for Delphi Pascal VCL | Open Sourc
 meta-desc: "Delphi Pascal unit for handling Windows shell folders. Includes a \"Browse for Folders\" dialogue box component. Requires Delphi 7 & later."
 download-base-url: "https://sourceforge.net/projects/ddablib/files/shellfolders/"
 repo-url: "https://github.com/ddablib/shellfolders"
+docs-url: "https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/ShellFoldersUnit.md"
 want-header-buttons: true
 status: "current"
 ---
@@ -200,7 +201,7 @@ status: "current"
   </div>
   <div class="panel-body">
     <p>
-      The <em>{{page.title}}</em> is comprehensively documented online <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/ShellFoldersUnit.md" aria-title="View the online documentation">here</a>
+      The <em>{{page.title}}</em> is comprehensively documented online <a href="{{ page.docs-url }}" aria-title="View the online documentation">here</a>
     </p>
     <p>
       The project's change log can be viewed <a href="https://raw.githubusercontent.com/ddablib/shellfolders/main/Docs/ChangeLog.txt" aria-title="View the change log in plain text">here</a>.
@@ -236,7 +237,7 @@ status: "current"
       If you have created a bug fix or have implemented a new feature please open a pull request for it.
     </p>
     <p>
-      Should you have any queries about using the unit please read the <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/ShellFoldersUnit.md">documentation</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
+      Should you have any queries about using the unit please read the <a href="{{ page.docs-url }}">documentation</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
     </p>
   </div>
 </section>

--- a/_software/streams.html
+++ b/_software/streams.html
@@ -15,6 +15,7 @@ meta-title: "TStream Extension Classes for Delphi Pascal | Open Source | 32 & 64
 meta-desc: "Delphi Pascal classes that wrap and operate on TStream classes: a base stream wrapper & various IStream adapter classes. Requires Delphi 4 & later."
 download-base-url: "https://sourceforge.net/projects/ddablib/files/streams/"
 repo-url: "https://github.com/ddablib/streams"
+docs-url: "https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/Streams.md"
 want-header-buttons: true
 status: "current"
 ---
@@ -150,7 +151,7 @@ status: "current"
   </div>
   <div class="panel-body">
     <p>
-      The <em>{{ page.title }}</em> are comprehensively documented online <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/Streams.md" aria-title="View the online documentation">here</a>
+      The <em>{{ page.title }}</em> are comprehensively documented online <a href="{{ page.docs-url }}" aria-title="View the online documentation">here</a>
     </p>
     <p>
       The project's change log can be viewed <a href="https://raw.githubusercontent.com/ddablib/streams/main/Docs/ChangeLog.txt" aria-title="View the change log in plain text">here</a>.
@@ -175,7 +176,7 @@ status: "current"
       If you have created a bug fix or have implemented a new feature please open a pull request for it.
     </p>
     <p>
-      Should you have any queries about using the classes please read the <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/Streams.md">documentation</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
+      Should you have any queries about using the classes please read the <a href="{{ page.docs-url }}">documentation</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
     </p>
   </div>
 </section>

--- a/_software/stringpe.html
+++ b/_software/stringpe.html
@@ -15,6 +15,7 @@ meta-title: "Multi-line String Property Editor for Delphi Pascal IDE | Open Sour
 meta-desc: "String and TCaption property editor extension for the Delphi IDE that enables multi-line strings to be entered via a dialogue box. For Delphi 6 & later."
 download-base-url: "https://sourceforge.net/projects/ddablib/files/stringpe/"
 repo-url: "https://github.com/ddablib/stringpe"
+docs-url: "https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/StringPE.md"
 want-header-buttons: true
 status: "current"
 ---
@@ -171,7 +172,7 @@ status: "current"
   <div class="panel-body">
     <p>
       The <em>{{ page.title }}</em> is documented online
-      <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/StringPE.md" aria-title="View the online documentation">here</a>. If presented with a choice of versions, choose version 2.
+      <a href="{{ page.docs-url }}" aria-title="View the online documentation">here</a>. If presented with a choice of versions, choose version 2.
     </p>
     <p>
       The project's change log can be viewed <a href="https://raw.githubusercontent.com/ddablib/stringpe/main/Docs/ChangeLog.txt" aria-title="View the change log in plain text">here</a>.
@@ -196,7 +197,7 @@ status: "current"
       If you have created a bug fix or have implemented a new feature please open a pull request for it.
     </p>
     <p>
-      Should you have any queries about using the editor please read the <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/StringPE.md">documentation</a> for version 2. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
+      Should you have any queries about using the editor please read the <a href="{{ page.docs-url }}">documentation</a> for version 2. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
     </p>
   </div>
 </section>

--- a/_software/sysinfo.html
+++ b/_software/sysinfo.html
@@ -15,6 +15,7 @@ meta-title: "System Information Classes for Delphi Pascal | Open Source | 32 & 6
 meta-desc: "A set of Delphi Pascal static classes that provide information about the host computer & Windows version information and system folders. Requires Delphi 7 & later."
 download-base-url: "https://sourceforge.net/projects/ddablib/files/sysinfo/"
 repo-url: "https://github.com/ddablib/sysinfo"
+docs-url: "https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/SystemInformationUnit.md"
 want-header-buttons: true
 status: "current"
 ---
@@ -218,7 +219,7 @@ status: "current"
   <div class="panel-body">
     <p>
       The <em>{{ page.title }}</em> is comprehensively documented online
-      <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/SystemInformationUnit.md" aria-title="View the online documentation">here</a>
+      <a href="{{ page.docs-url }}" aria-title="View the online documentation">here</a>
     </p>
     <p>
       The project's change log can be viewed <a href="https://raw.githubusercontent.com/ddablib/sysinfo/main/Docs/ChangeLog.txt" aria-title="View the change log in plain text">here</a>.
@@ -243,7 +244,7 @@ status: "current"
       If you have created a bug fix or have implemented a new feature please open a pull request for it.
     </p>
     <p>
-      Should you have any queries about using the classes please read the <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/SystemInformationUnit.md">documentation</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
+      Should you have any queries about using the classes please read the <a href="{{ page.docs-url }}">documentation</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>.
     </p>
   </div>
 </section>

--- a/_software/verinfo.html
+++ b/_software/verinfo.html
@@ -15,6 +15,7 @@ meta-title: "Version Information Reader Component for Delphi Pascal VCL & FMX | 
 meta-desc: "Delphi Pascal VCL & FMX component that accesses version information embedded in Windows program & DLL resources. Requires Delphi 2 & later."
 download-base-url: "https://sourceforge.net/projects/ddablib/files/verinfo/"
 repo-url: "https://github.com/ddablib/verinfo"
+docs-url: "https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/VerInfo.md"
 want-header-buttons: true
 status: "current"
 ---
@@ -165,7 +166,7 @@ status: "current"
   </div>
   <div class="panel-body">
     <p>
-      The <em>{{ page.title }}</em> is comprehensively documented online <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/VerInfo.md" aria-title="View the online documentation">here</a>
+      The <em>{{ page.title }}</em> is comprehensively documented online <a href="{{ page.docs-url }}" aria-title="View the online documentation">here</a>
     </p>
     <p>
       The project's change log can be viewed <a href="https://raw.githubusercontent.com/ddablib/verinfo/main/Docs/ChangeLog.txt" aria-title="View the change log in plain text">here</a>.
@@ -201,7 +202,7 @@ status: "current"
       If you have created a bug fix or have implemented a new feature please open a pull request for it.
     </p>
     <p>
-      Should you have any queries about using the component please read the <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/VerInfo.md">documentation</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>
+      Should you have any queries about using the component please read the <a href="{{ page.docs-url }}">documentation</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>
     </p>
   </div>
 </section>

--- a/_software/wdwstate.html
+++ b/_software/wdwstate.html
@@ -15,6 +15,7 @@ meta-title: "Window State Save & Restore Components for Delphi Pascal VCL | Open
 meta-desc: "Three Delphi Pascal VCL components for saving and restoring a window's position in the registry, ini file or custom storage. Requires Delphi 5 & later."
 download-base-url: "https://sourceforge.net/projects/ddablib/files/wdwstate/"
 repo-url: "https://github.com/ddablib/wdwstate"
+docs-url: "https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/WindowStateComponents.md"
 want-header-buttons: true
 status: "current"
 ---
@@ -214,7 +215,7 @@ status: "current"
   </div>
   <div class="panel-body">
     <p>
-      The <em>{{ page.title }}</em> are comprehensively documented online <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/WindowStateComponents.md" aria-title="View the online documentation">here</a>
+      The <em>{{ page.title }}</em> are comprehensively documented online <a href="{{ page.docs-url }}" aria-title="View the online documentation">here</a>
     </p>
     <p>
       The project's change log can be viewed <a href="https://raw.githubusercontent.com/ddablib/wdwstate/main/Docs/ChangeLog.txt" aria-title="View the change log in plain text">here</a>.
@@ -253,7 +254,7 @@ status: "current"
       If you have created a bug fix or have implemented a new feature please open a pull request for it.
     </p>
     <p>
-      Should you have any queries about using the components please read the <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/WindowStateComponents.md">documentation</a> and/or <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/FAQs/WindowStateComponents.md">FAQ</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>
+      Should you have any queries about using the components please read the <a href="{{ page.docs-url }}">documentation</a> and/or <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/FAQs/WindowStateComponents.md">FAQ</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>
     </p>
   </div>
 </section>

--- a/_software/wdwstate.html
+++ b/_software/wdwstate.html
@@ -16,6 +16,7 @@ meta-desc: "Three Delphi Pascal VCL components for saving and restoring a window
 download-base-url: "https://sourceforge.net/projects/ddablib/files/wdwstate/"
 repo-url: "https://github.com/ddablib/wdwstate"
 docs-url: "https://github.com/delphidabbler/ddab-lib-docs/blob/master/Docs/WindowStateComponents.md"
+faq-url: "https://github.com/delphidabbler/ddab-lib-docs/blob/master/FAQs/WindowStateComponents.md"
 want-header-buttons: true
 status: "current"
 ---
@@ -235,7 +236,7 @@ status: "current"
 			</p>
     </div>
     <p>
-      There is also an <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/FAQs/WindowStateComponents.md">FAQ</a>.
+      There is also an <a href="{{ page.faq-url }}">FAQ</a>.
     </p>
   </div>
 </section>
@@ -254,7 +255,7 @@ status: "current"
       If you have created a bug fix or have implemented a new feature please open a pull request for it.
     </p>
     <p>
-      Should you have any queries about using the components please read the <a href="{{ page.docs-url }}">documentation</a> and/or <a href="https://github.com/delphidabbler/ddab-lib-docs/blob/master/FAQs/WindowStateComponents.md">FAQ</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>
+      Should you have any queries about using the components please read the <a href="{{ page.docs-url }}">documentation</a> and/or <a href="{{ page.faq-url }}">FAQ</a>. If you can't find an answer in the documentation then post a message in the <a href="https://github.com/delphidabbler/ddablib/discussions">discussion group</a>
     </p>
   </div>
 </section>


### PR DESCRIPTION
Use front matter variable to store documentation URL on software pages.

Update documentation URLs as necessary.