### PR TITLE
Create url/ddablib-docs.html

### DIFF
--- a/url/ddablib-docs.html
+++ b/url/ddablib-docs.html
@@ -1,0 +1,5 @@
+---
+layout: url-redirect
+redirect-url: https://github.com/delphidabbler/ddab-lib-docs/blob/master/README.md
+title: Redirecting...
+---


### PR DESCRIPTION
Redirect to ddablib documentation.

Closes #119